### PR TITLE
fix: disable CloudBees sidecar injector for the delivery pod

### DIFF
--- a/templates/delivery/Jenkinsfile
+++ b/templates/delivery/Jenkinsfile
@@ -19,6 +19,9 @@ pipeline {
       yaml """
       apiVersion: v1
       kind: Pod
+      metadata:
+        annotations:
+          com.cloudbees.sidecar-injector/inject: no
       spec:
         restartPolicy: Never
         containers:


### PR DESCRIPTION
This sidecar causes issues with certain container image builds in kaniko. https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/cloudbees-ci-on-modern-cloud-platforms/cannot-build-images-with-kaniko-due-to-the-sidecar-injector