### PR TITLE
SAST: Fix the way the pipeline determines the default branch in SonarQube

### DIFF
--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -79,6 +79,7 @@ pipeline {
               def projectBranchesJson = sh(
                 script: """
                   #! /bin/sh -e
+                  set +x
                   curl --location '${projectBranchesUrl}' \
                     --header "Authorization: Basic \$(echo -n \${SONAR_TOKEN}: | base64)" \
                     --no-progress-meter -f

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
                 """,
                 returnStdout: true
               )
+              echo "Fetched SonarQube project settings: ${projectSettingsJson}"
               def defaultBranch =
                 new groovy.json.JsonSlurper().parseText(projectSettingsJson).settings.find { it.key == 'sonar.projectCreation.mainBranchName' }?.value ?: 'main'
               def args = [
@@ -94,8 +95,10 @@ pipeline {
                 "-Dsonar.qualitygate.wait=true"
               ]
               if (params.git_branch == defaultBranch) {
+                echo "Performing analysis for the default branch: ${defaultBranch}"
                 args.add("-Dsonar.branch.name=${params.git_branch}")
               } else {
+                echo "Performing analysis for a feature branch: ${params.git_branch} (does not match default branch ${defaultBranch})"
                 args.add("-Dsonar.pullrequest.branch=${params.git_branch ?: params.git_commit}")
                 args.add("-Dsonar.pullrequest.key=${params.git_change_id ?: (params.git_branch ?: params.git_commit)}")
               }

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -76,16 +76,15 @@ pipeline {
           withCredentials([string(credentialsId: "${sonarqube_token}", variable: 'SONAR_TOKEN')]) {
             script {
               def projectBranchesUrl = "${params.sonarqube_url}/api/project_branches/list?project=${params.sonarqube_project_key}"
-              sh "set +x" // Disable command echoing
               def projectBranchesJson = sh(
                 script: """
+                  #! /bin/sh -e
                   curl --location '${projectBranchesUrl}' \
                     --header "Authorization: Basic \$(echo -n \${SONAR_TOKEN}: | base64)" \
                     --no-progress-meter -f
                 """,
                 returnStdout: true
               )
-              sh "set -x"
               echo "Fetched SonarQube project branch list: ${projectBranchesJson}"
               def defaultBranch =
                 new groovy.json.JsonSlurper().parseText(projectBranchesJson).branches.find { it.isMain }?.name ?: 'main'

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -75,18 +75,20 @@ pipeline {
         container('sonarqube') {
           withCredentials([string(credentialsId: "${sonarqube_token}", variable: 'SONAR_TOKEN')]) {
             script {
-              def project_settings_url = "${params.sonarqube_url}/api/settings/values?component=${params.sonarqube_project_key}"
-              def projectSettingsJson = sh(
+              def projectBranchesUrl = "${params.sonarqube_url}/api/project_branches/list?project=${params.sonarqube_project_key}"
+              sh "set +x" // Disable command echoing
+              def projectBranchesJson = sh(
                 script: """
-                  curl --location '${project_settings_url}&keys=sonar.projectCreation.mainBranchName' \
+                  curl --location '${projectBranchesUrl}' \
                     --header "Authorization: Basic \$(echo -n \${SONAR_TOKEN}: | base64)" \
                     --no-progress-meter -f
                 """,
                 returnStdout: true
               )
-              echo "Fetched SonarQube project settings: ${projectSettingsJson}"
+              sh "set -x"
+              echo "Fetched SonarQube project branch list: ${projectBranchesJson}"
               def defaultBranch =
-                new groovy.json.JsonSlurper().parseText(projectSettingsJson).settings.find { it.key == 'sonar.projectCreation.mainBranchName' }?.value ?: 'main'
+                new groovy.json.JsonSlurper().parseText(projectBranchesJson).branches.find { it.isMain }?.name ?: 'main'
               def args = [
                 '-Dsonar.login=$SONAR_TOKEN',
                 "-Dsonar.host.url=${params.sonarqube_url}",


### PR DESCRIPTION
The mechanism that was previously used did not reflect changes to the default branch after project creation.