### PR TITLE
delivery: apply the build memory limit to the BuildX container as well as to Buildkit.

### DIFF
--- a/templates/delivery/Jenkinsfile
+++ b/templates/delivery/Jenkinsfile
@@ -48,6 +48,9 @@ pipeline {
         - name: buildx
           image: docker:latest
           command: ['tail', '-f', '/dev/null']
+          resources:
+            limits:
+              memory: "${params.build_memory_limit}"
         - name: clamav
           image: artifactory.cloud.cms.gov/docker/clamav/clamav:latest
           command: ['tail', '-f', '/dev/null']


### PR DESCRIPTION
The Buildx container appears to use a sizable amount of memory when performing the container image export.