### PR TITLE
Specfy imagePullPolicy latest everywhere so we don't wind up running deprecated images.

### DIFF
--- a/templates/delivery/Jenkinsfile
+++ b/templates/delivery/Jenkinsfile
@@ -208,6 +208,7 @@ pipeline {
                 try {
                   withCredentials([string(credentialsId: "${snyk_token}", variable: 'SNYK_TOKEN')]) {
                     sh """
+                      snyk --version
                       # Report vulnerabilities to the Snyk dashboard
                       snyk container monitor ${args.join(' ')}
                       snyk container sbom --format=${sbom_format} oci-archive:image.oci.tar > './snyk-sbom.${sbom_ext}'

--- a/templates/delivery/Jenkinsfile
+++ b/templates/delivery/Jenkinsfile
@@ -41,15 +41,18 @@ pipeline {
         containers:
         - name: fetch
           image: artifactory.cloud.cms.gov/docker/alpine:3
+          imagePullPolicy: Always
           command: ['tail', '-f', '/dev/null']
         - name: buildx
           image: docker:latest
+          imagePullPolicy: Always
           command: ['tail', '-f', '/dev/null']
           resources:
             limits:
               memory: "${params.build_memory_limit}"
         - name: clamav
           image: artifactory.cloud.cms.gov/docker/clamav/clamav:latest
+          imagePullPolicy: Always
           command: ['tail', '-f', '/dev/null']
           resources:
             limits:
@@ -58,10 +61,12 @@ pipeline {
               memory: "3Gi"
         - name: snyk
           image: artifactory.cloud.cms.gov/docker/snyk/snyk:alpine
+          imagePullPolicy: Always
           command: ['tail', '-f', '/dev/null']
         - name: skopeo
           # pull through from quay.io
           image: artifactory.cloud.cms.gov/docker/skopeo/stable:v1
+          imagePullPolicy: Always
           command: ['tail', '-f', '/dev/null']
       """
     }

--- a/templates/deployment/Jenkinsfile
+++ b/templates/deployment/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
         containers:
         - name: fetch
           image: artifactory.cloud.cms.gov/docker/alpine:3
+          imagePullPolicy: Always
           command: ['tail', '-f', '/dev/null']
       """
     }

--- a/templates/jenkins-secret-provisioner/Jenkinsfile
+++ b/templates/jenkins-secret-provisioner/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
         containers:
         - name: kubectl
           image: artifactory.cloud.cms.gov/docker/bitnami/kubectl:1.29
+          imagePullPolicy: Always
           command: ['tail', '-f', '/dev/null']
         securityContext:
           runAsUser: 1001

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -2,9 +2,11 @@ def containerListYaml(snyk_image_tag) {
   def containerListYaml = reindent(10, """
     - name: fetch
       image: artifactory.cloud.cms.gov/docker/alpine:3
+      imagePullPolicy: Always
       command: ['tail', '-f', '/dev/null']
     - name: sonarqube
       image: artifactory.cloud.cms.gov/docker/sonarsource/sonar-scanner-cli:5
+      imagePullPolicy: Always
       command: ['tail', '-f', '/dev/null']
       resources:
         limits:
@@ -15,6 +17,7 @@ def containerListYaml(snyk_image_tag) {
     containerListYaml += reindent(10, """
       - name: snyk
         image: artifactory.cloud.cms.gov/docker/snyk/snyk:$snyk_image_tag
+        imagePullPolicy: Always
         command: ['tail', '-f', '/dev/null']""")
   }
 

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -168,6 +168,7 @@ pipeline {
                   withEnv(env) {
                     withCredentials([string(credentialsId: "${snyk_token}", variable: 'SNYK_TOKEN')]) {
                       sh """
+                        snyk --version
                         # Report vulnerabilities to the Snyk dashboard
                         snyk monitor ${args.join(' ')}
                         # Report detected vulnerabilities to stdout and raise an error if


### PR DESCRIPTION
We were notified by the Snyk folks that we are apparently running some deprecated snyk images, presumably due to caching. This should resolve that issue.