### PR TITLE
add clamscan size parameter

### DIFF
--- a/.github/workflows/update-wiki.yaml
+++ b/.github/workflows/update-wiki.yaml
@@ -1,0 +1,39 @@
+name: Update Wiki
+
+on:
+  push:
+    paths:
+      - 'README.md'
+
+permissions:
+  contents: write
+
+jobs:
+  update-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Checkout Wiki
+        uses: actions/checkout@v2
+        with:
+          repository: CMS-Enterprise/delivery-pipeline-templates.wiki
+          path: wiki
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Copy README to Wiki
+        run: cp README.md wiki/Home.md
+
+      - name: Commit and Push to Wiki
+        run: |
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "[chore] sync README.md"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ This repository contains a Jenkins [Pipeline Template Catalog](https://docs.clou
 
 The following pipeline templates are available in this catalog:
 
-* [SAST Scan](./templates/sast/README.md) - Runs Static Application Security Testing (SAST) scans on the application code (using SonarQube).
-* [Delivery Pipeline](./templates/delivery/README.md) - Runs container build and scan steps and publishes the resulting container image to the CMS container registry (Artifactory).
-* [GitOps Deployment](./templates/deployment/README.md) - Runs steps to deploy the container image to a Kubernetes cluster by updating the image tag in Kubernetes manifests.
+* [SAST Scan](https://github.com/CMS-Enterprise/delivery-pipeline-templates/blob/419aec7ae2da320b57a139d8331c96015f08708a/templates/sast/README.md) - Runs Static Application Security Testing (SAST) scans on the application code (using SonarQube).
+* [Delivery Pipeline](https://github.com/CMS-Enterprise/delivery-pipeline-templates/blob/419aec7ae2da320b57a139d8331c96015f08708a/templates/delivery/README.md) - Runs container build and scan steps and publishes the resulting container image to the CMS container registry (Artifactory).
+* [GitOps Deployment](https://github.com/CMS-Enterprise/delivery-pipeline-templates/blob/419aec7ae2da320b57a139d8331c96015f08708a/templates/deployment/README.md) - Runs steps to deploy the container image to a Kubernetes cluster by updating the image tag in Kubernetes manifests.
 
 # Architecture
 
 The pipeline templates in this catalog are designed to be used by invoking them from another Jenkins Pipeline that will typically be a Multi-Branch Pipeline that runs when the source code of a project changes, and/or can run with different configurations for different branches.
 
-![](./static/images/Jenkins%20Delivery%20Pipelines%20-%20Architecture.png)
+![](https://github.com/CMS-Enterprise/delivery-pipeline-templates/blob/419aec7ae2da320b57a139d8331c96015f08708a/static/images/Jenkins%20Delivery%20Pipelines%20-%20Architecture.png)
 
-![](./static/images/Jenkins%20Delivery%20Pipelines%20-%20Sequence.png)
+![](https://github.com/CMS-Enterprise/delivery-pipeline-templates/blob/419aec7ae2da320b57a139d8331c96015f08708a/static/images/Jenkins%20Delivery%20Pipelines%20-%20Sequence.png)
 
 ## Tools
 
@@ -28,7 +28,7 @@ The pipeline templates in this catalog are designed to be used by invoking them 
 | SAST       | Scan Source        | SonarQube                                            |
 | Delivery   | Build Image        | Kaniko                                               |
 | Delivery   | Vulnerability Scan | Snyk                                                 |
-| Delivery   | Malware Scan       | ClamAV (to be replaced by TrendMicro when available) |
+| Delivery   | Malware Scan       | ClamAV                                               |
 | Delivery   | Publish Image      | Crane -> Artifactory                                 |
 | Deployment | Update Image Tags  | Kustomize                                            |
 | Deployment | Commit & Push      | Git -> ArgoCD                                        |
@@ -49,11 +49,11 @@ To use the Pipeline Templates in this catalog, the [CloudBees Pipeline: Template
 
 From the Jenkins dashboard, select "Pipeline Template Catalogs" and then click the "Add catalog" link under that.
 
-![The Pipeline Template Catalogs Menu](./static/images/Pipeline%20Template%20Catalogs%20-%20Add.png)
+![The Pipeline Template Catalogs Menu](https://github.com/CMS-Enterprise/delivery-pipeline-templates/blob/419aec7ae2da320b57a139d8331c96015f08708a/static/images/Pipeline%20Template%20Catalogs%20-%20Add.png)
 
 Select the Branch or Tag that you want to utilize. Selecting the `main` branch will give you the latest version of the templates, however it could lead to breaking changes being automatically introduced during a future update. Selecting a "stable" version branch such as `v1` will give you a stable version of the templates that will not introduce breaking changes, but will be updated with bug and security fixes. Selecting a specific version tag such as `v1.0.0` will give you a specific version of the templates that will not be updated.
 
-![New Pipeline Catalog Source Control Options](./static/images/Catalog%20Source%20Control%20Options.png)
+![New Pipeline Catalog Source Control Options](https://github.com/CMS-Enterprise/delivery-pipeline-templates/blob/419aec7ae2da320b57a139d8331c96015f08708a/static/images/Catalog%20Source%20Control%20Options.png)
 
 Enter the URL of this repository (`https://github.com/CMS-Enterprise/delivery-pipeline-templates.git`) in the "Catalog source code repository location" section, and click Save.
 

--- a/templates/delivery/Jenkinsfile
+++ b/templates/delivery/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
 
     string(name: 'snyk_project_name', defaultValue: "${default_snyk_project_name ?: 'my-app'}", description: 'The name of the Snyk project to associate the container image scan with.')
     string(name: 'vulnerability_severity_threshold', defaultValue: "${default_vulnerability_severity_threshold ?: 'high'}", description: 'The minimum severity level of vulnerabilities which will cause the build to fail if detected (options: low, medium, high, critical).')
+    string(name: 'clamscan_size_limit', defaultValue: "${default_clamscan_size_limit ?: '500M'}", description: "clamscan file & scan size limits")
     booleanParam(name: 'clamscan_enabled', defaultValue: true, description: 'optionally enable/disable the clamscan antivirus scan.')
     booleanParam(name: 'continue_on_image_scan_failure', defaultValue: "${default_continue_on_image_scan_failure ?: false}", description: 'When set to true, the pipeline will continue to the image publish step even if either of the malware scan or vulnerability scan fails for any reason.')
   }
@@ -255,14 +256,28 @@ pipeline {
                     echo "Freshclam exited with code ${freshclamExitCode}"
                     error 'Failed to update ClamAV database.'
                   }
+
+                  def args = [
+                    '--infected',
+                    '--recursive',
+                    '--scan-archive=yes',
+                    "--max-filesize=${params.clamscan_size_limit}",
+                    "--max-scansize=${params.clamscan_size_limit}",
+                    "--log=virus-report.clamav.txt",
+                    "--alert-exceeds-max",
+                    "--stdout",
+                    "./image-raw"
+                  ]
+
+
                   echo "ClamAV database updated successfully, running clamscan"
                   sh """
-                    # Note: while clamscan can scan a tar files contents recursively, the
-                    # max-filesize and max-scansize limit still apply to the tar file itself. So if
-                    # the image tar files is scanned unextracted it will be a no-op if the file is
-                    # larger than the max-filesize limit.
-                    clamscan --infected --recursive --scan-archive=yes --max-filesize=500M --max-scansize=500M \
-                             --log virus-report.clamav.txt --stdout ./image-raw
+                    # Note: while clamscan can scan a tar files contents recursively, the tar or zip files
+                    # in the image are still subject to the file / scan size limits BEFORE the untar / unzip.
+                    # If a file exists that exceeds the limit, the command will exit code 1, causing the job
+                    # to fail. Use the clamscan_size_limit parameter to increase as needed.
+
+                    clamscan ${args.join(' ')}
 
                     chmod a+r virus-report.clamav.txt
                   """

--- a/templates/delivery/README.md
+++ b/templates/delivery/README.md
@@ -34,8 +34,8 @@ The Delivery Pipeline is a [parameterized pipeline](https://www.jenkins.io/doc/b
 | continue_on_image_scan_failure   | X        | X        | When set to true, the pipeline will continue to the image publish step even if either of the malware scan or vulnerability scan fails for any reason. | false            |
 | build_retention_days             |          | X        | The number of days to retain build logs and artifacts.                                                                                                | 90               |
 | build_retention_count            |          | X        | The number of builds to retain.                                                                                                                       | 1000             |
+| clamscan_size_limit              | X        | X        | The limit set for both the filesize_limit and scansize_limit for the clamscan cli                                                                     | 500M             |
 
-# Usage
 
 For general usage see the [CMS ADO Pipeline Catalog README](../../README.md).
 
@@ -134,7 +134,7 @@ When a container scan results are reported to Snyk, the results are associated w
 
 ## Delivery Pipeline Artifacts
 
-The Delivery Pipeline produces the following artifacts when Snyk and/or ClamAV are enabled respectively: 
+The Delivery Pipeline produces the following artifacts when Snyk and/or ClamAV are enabled respectively:
 
  * `snyk-vulnerabilities.json`
  * `snyk-sbom.json`

--- a/templates/delivery/template.yaml
+++ b/templates/delivery/template.yaml
@@ -98,7 +98,7 @@ parameters:
     description: "The number of builds to retain."
     type: string
     defaultValue: "1000"
-  - name: clamscan_size_limit
+  - name: default_clamscan_size_limit
     displayName: Clamscan file & scan size limits
     description: "The limit set for both the filesize_limit and scansize_limit for the clamscan cli"
     defaultValue: "500M"

--- a/templates/delivery/template.yaml
+++ b/templates/delivery/template.yaml
@@ -98,3 +98,7 @@ parameters:
     description: "The number of builds to retain."
     type: string
     defaultValue: "1000"
+  - name: clamscan_size_limit
+    displayName: Clamscan file & scan size limits
+    description: "The limit set for both the filesize_limit and scansize_limit for the clamscan cli"
+    defaultValue: "500M"


### PR DESCRIPTION
This PR adds a parameter to set the `max-filesize` and `max-scanscan` arguments in the clamscan command.

The default value is set to `500M` which can be reduced for improved performance or increased for images that may contain large files.

This PR also adds the `--alert-exceeds-max` flag which results in an exit code 1 if a file is too large to be scanned.

Commits:

- **feat: add clamscan size parameter**
- **docs: update doc links**
- **fix: add default value for clamscan size limit**


