### PR TITLE
feat: add parameter for clamscan to target oci or raw image output

### DIFF
--- a/templates/delivery/Jenkinsfile
+++ b/templates/delivery/Jenkinsfile
@@ -24,8 +24,9 @@ pipeline {
 
     string(name: 'snyk_project_name', defaultValue: "${default_snyk_project_name ?: 'my-app'}", description: 'The name of the Snyk project to associate the container image scan with.')
     string(name: 'vulnerability_severity_threshold', defaultValue: "${default_vulnerability_severity_threshold ?: 'high'}", description: 'The minimum severity level of vulnerabilities which will cause the build to fail if detected (options: low, medium, high, critical).')
-    string(name: 'clamscan_size_limit', defaultValue: "${default_clamscan_size_limit ?: '500M'}", description: "clamscan file & scan size limits")
     booleanParam(name: 'clamscan_enabled', defaultValue: true, description: 'optionally enable/disable the clamscan antivirus scan.')
+    booleanParam(name: 'clamscan_oci_tar', defaultValue: false, description: 'if enabled, clamscan will scan the entire tar archive rather than a flat file system which could improve performance')
+    string(name: 'clamscan_size_limit', defaultValue: "${default_clamscan_size_limit ?: '500M'}", description: "clamscan file & scan size limits")
     booleanParam(name: 'continue_on_image_scan_failure', defaultValue: "${default_continue_on_image_scan_failure ?: false}", description: 'When set to true, the pipeline will continue to the image publish step even if either of the malware scan or vulnerability scan fails for any reason.')
   }
 
@@ -141,8 +142,14 @@ pipeline {
                 "--file=${params.dockerfile}",
                 "--tag=${params.image}:${params.tag}",
                 "--output type=oci,dest=./image.oci.tar",
-                "--output type=local,dest=./image-raw"
               ]
+
+              if (params.clamscan_oci_tar)  {
+                echo "Option 'clamscan_oci_tar' set to true. Only building OCI tar"
+              } else {
+                echo "Option 'clamscan_oci_tar' set to false. Adding build output of raw image filesystem"
+                arguments.add("--output type=local,dest=./image-raw")
+              }
 
               if (params.build_target) {
                 echo "build_target (${params.build_target.getClass()}): ${params.build_target}"
@@ -266,9 +273,15 @@ pipeline {
                     "--log=virus-report.clamav.txt",
                     "--alert-exceeds-max",
                     "--stdout",
-                    "./image-raw"
                   ]
 
+                  if (params.clamscan_oci_tar)  {
+                    echo "Option 'clamscan_oci_tar' set to true. Scanning OCI tar instead of raw image filesystem"
+                    args.add("./image.oci.tar")
+                  } else {
+                    echo "Option 'clamscan_oci_tar' set to false. Scanning raw image filesystem"
+                    args.add("./image-raw")
+                  }
 
                   echo "ClamAV database updated successfully, running clamscan"
                   sh """

--- a/templates/delivery/README.md
+++ b/templates/delivery/README.md
@@ -35,6 +35,7 @@ The Delivery Pipeline is a [parameterized pipeline](https://www.jenkins.io/doc/b
 | build_retention_days             |          | X        | The number of days to retain build logs and artifacts.                                                                                                | 90               |
 | build_retention_count            |          | X        | The number of builds to retain.                                                                                                                       | 1000             |
 | clamscan_size_limit              | X        | X        | The limit set for both the filesize_limit and scansize_limit for the clamscan cli                                                                     | 500M             |
+| clamscan_oci_tar                 | X        | X        | Set Clamscan to scan the OCI tar archive instead of the raw filesystem. May need to increase scansize limitations                                     | false            |
 
 
 For general usage see the [CMS ADO Pipeline Catalog README](../../README.md).


### PR DESCRIPTION
This PR adds the option to scan either the oci image archive (tar file) or build and scan the images flat file system (called raw)

