### PR TITLE
Update SonarQube scanner config and resources

### DIFF
--- a/REMEDIATION_BACKLOG.md
+++ b/REMEDIATION_BACKLOG.md
@@ -1,0 +1,348 @@
+# CMS TRA Remediation Backlog — Delivery Pipeline Templates
+
+**Audit Date:** 2026-05-04  
+**Audited Scope:** `templates/sast/`, `templates/delivery/`, `templates/deployment/`, `templates/jenkins-secret-provisioner/`  
+**TRA Compliance Result:** Non-compliant across all four contexts (CI/CD DevSecOps Pipeline, Container Deployment, Identity Management, Cloud Infrastructure)  
+**Backlog Owner:** Platform Engineering / DevSecOps  
+
+---
+
+## Definition of Done (Secure Pipeline Changes)
+
+All items in this backlog are "Done" when:
+
+- [ ] Code change merged to `main` with peer review
+- [ ] Relevant TRA rule ID cited in the PR description
+- [ ] No new `latest` or undigested image tags introduced
+- [ ] `kubectl auth can-i` or equivalent RBAC check passes with least-privilege
+- [ ] Pipeline run succeeds end-to-end in a non-prod environment
+- [ ] Security scan (SAST + container scan) returns no new HIGH/CRITICAL findings
+- [ ] Change documented in `CHANGELOG.md`
+
+---
+
+## Epic 1 — Quick Wins: Eliminate Critical Vulnerabilities (0–30 days)
+
+**Goal:** Remove immediate high-risk violations of mandatory TRA Business Rules.
+
+---
+
+### Story 1.1 — Pin All Container Image Tags to Immutable Digests
+
+**TRA Rules:** BR-OR-1, BR-SBI-2, RP-CA-1  
+**Priority:** Critical  
+**Effort:** S (2–4 hrs)
+
+**Problem:** All four Jenkinsfiles pull mutable image tags (`docker:latest`, `clamav/clamav:latest`, `snyk/snyk:alpine`, `owasp/dependency-check-action:latest`). A supply-chain compromise or tag overwrite silently changes pipeline behavior.
+
+**Affected Files & Lines:**
+
+| File | Line | Current Value | Required Fix |
+|------|------|---------------|--------------|
+| `templates/delivery/Jenkinsfile` | 50 | `docker:latest` | `docker:27.5.1@sha256:<digest>` |
+| `templates/delivery/Jenkinsfile` | 57 | `clamav/clamav:latest` | `clamav/clamav:1.4.2@sha256:<digest>` |
+| `templates/delivery/Jenkinsfile` | 66 | `snyk/snyk:alpine` | `snyk/snyk:alpine@sha256:<digest>` |
+| `templates/sast/Jenkinsfile` | 8 | `owasp/dependency-check-action:latest` | pin to specific release digest |
+| `templates/sast/Jenkinsfile` | (sonar scanner) | mutable tag | pin to digest |
+
+**Acceptance Criteria:**
+
+- [ ] Every container image reference in all Jenkinsfiles uses `image:tag@sha256:<digest>` format
+- [ ] A `PINNED_IMAGES.md` or inline comment records the resolved digest date for each image
+- [ ] `imagePullPolicy: IfNotPresent` set where digest is pinned (digest already guarantees immutability)
+- [ ] CI pipeline validates no `latest` or digest-less references via a `grep` lint step
+- [ ] Images sourced from Artifactory (`artifactory.cloud.cms.gov`) where CMS-approved mirrors exist, satisfying BR-OR-5
+
+---
+
+### Story 1.2 — Remove `StrictHostKeyChecking=no` from Deployment Pipeline
+
+**TRA Rules:** BR-URL-5, BR-OR-3, RP-CA-6  
+**Priority:** Critical  
+**Effort:** S (1–2 hrs)
+
+**Problem:** `templates/deployment/Jenkinsfile` lines 94 and 120 use `ssh -o StrictHostKeyChecking=no`, disabling host key verification and enabling MITM attacks against the GitOps push step.
+
+**Affected Files & Lines:**
+
+| File | Lines | Current Value |
+|------|-------|---------------|
+| `templates/deployment/Jenkinsfile` | 94, 120 | `ssh -o StrictHostKeyChecking=no` |
+
+**Acceptance Criteria:**
+
+- [ ] `StrictHostKeyChecking=no` removed from both occurrences
+- [ ] Known-hosts file pre-seeded in the Jenkins agent pod spec or mounted as a ConfigMap (`ssh-keyscan` output committed to repo)
+- [ ] Alternatively, switch GitOps push to HTTPS with token (no SSH) and remove SSH entirely
+- [ ] Deployment pipeline run validates the host key during the git push step
+- [ ] No `StrictHostKeyChecking=no` or `StrictHostKeyChecking=accept-new` appears in any template (enforced by lint)
+
+---
+
+### Story 1.3 — Remove Credentials from HTTPS Git Push URL
+
+**TRA Rules:** BR-URL-5, BR-KSM-4  
+**Priority:** Critical  
+**Effort:** S (2–3 hrs)
+
+**Problem:** `templates/deployment/Jenkinsfile` line 88 constructs an HTTPS push URL that embeds the `GIT_CREDENTIALS` value directly in the URL string. This exposes secrets in Jenkins logs, process listings, and git reflog.
+
+**Affected Files & Lines:**
+
+| File | Line | Current Pattern |
+|------|------|-----------------|
+| `templates/deployment/Jenkinsfile` | 88 | `https://${GIT_CREDENTIALS}@<host>/...` |
+
+**Acceptance Criteria:**
+
+- [ ] Credential embedded URL replaced with `git credential.helper` or `git push` via `GIT_ASKPASS` env var
+- [ ] OR switch transport to SSH with a key credential (not password-in-URL)
+- [ ] Jenkins log masking confirmed — no token appears in archived build logs
+- [ ] `withCredentials` wrapper used so Jenkins masks the value automatically
+- [ ] Credential never interpolated directly into a URL string
+
+---
+
+### Story 1.4 — Enforce `continue_on_image_scan_failure=false` as Non-Overridable Default
+
+**TRA Rules:** BR-OR-1, BR-OR-3, RP-CA-9  
+**Priority:** High  
+**Effort:** S (1–2 hrs)
+
+**Problem:** `templates/delivery/template.yaml` line 86 exposes `continue_on_image_scan_failure` as a configurable parameter with default `false`. Teams can set `true` at catalog instantiation, bypassing the container vulnerability gate entirely.
+
+**Affected Files & Lines:**
+
+| File | Line | Current |
+|------|------|---------|
+| `templates/delivery/template.yaml` | 86 | `default: false` (overridable) |
+| `templates/delivery/Jenkinsfile` | (scan step) | respects override |
+
+**Acceptance Criteria:**
+
+- [ ] `continue_on_image_scan_failure` parameter removed from `template.yaml` (no longer a caller-configurable option)
+- [ ] Jenkinsfile hardcodes `failOnIssues: true` (or equivalent) for the container scan step
+- [ ] Exception path: if a team has a documented risk acceptance, the override must require a separate approval parameter gated by a shared-library policy function, not a simple boolean
+- [ ] README updated to document that the scan gate is mandatory per CMS TRA BR-OR-1
+
+---
+
+### Story 1.5 — Add Pod Security Contexts to All Jenkins Agent Pod Specs
+
+**TRA Rules:** BR-OR-1, RP-CA-3, RP-CA-4, RP-CA-8  
+**Priority:** High  
+**Effort:** M (4–6 hrs)
+
+**Problem:** Three of four Jenkinsfiles (`sast`, `delivery`, `deployment`) define pod templates with no `securityContext`. The `jenkins-secret-provisioner` template has `runAsUser: 1001` on one container but no pod-level context and no `readOnlyRootFilesystem` or capability drops.
+
+**Affected Files:**
+
+- `templates/sast/Jenkinsfile`
+- `templates/delivery/Jenkinsfile`
+- `templates/deployment/Jenkinsfile`
+- `templates/jenkins-secret-provisioner/Jenkinsfile`
+
+**Acceptance Criteria:**
+
+- [ ] All pod specs include a pod-level `securityContext`:
+  ```yaml
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000        # or image-specific non-root UID
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  ```
+- [ ] All containers include a container-level `securityContext`:
+  ```yaml
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+  ```
+- [ ] `readOnlyRootFilesystem: true` paired with `emptyDir` volume mounts for any writable paths the tool requires (e.g., `/tmp`, `/home/scanner/.sonar`)
+- [ ] Docker-in-Docker (`docker:latest`) container reviewed separately — document why privileged is required if it remains, or replace with rootless BuildKit
+- [ ] All pods pass `kubectl auth can-i` checks with least-privilege service account
+
+---
+
+## Epic 2 — Control Strengthening (30–60 days)
+
+**Goal:** Harden pipeline controls, migrate to KSM-compliant secret management, and establish security visibility.
+
+---
+
+### Story 2.1 — Replace Runtime Kustomize Binary Download with Pinned In-Image Binary
+
+**TRA Rules:** BR-SBI-2, BR-OR-1, RP-SBI-4  
+**Priority:** High  
+**Effort:** M (4–8 hrs)
+
+**Problem:** `templates/deployment/Jenkinsfile` downloads the `kustomize` binary from `github.com` at runtime. This creates an untrusted runtime dependency: the download URL could be hijacked, the binary could change between runs, or network failures break deployments.
+
+**Acceptance Criteria:**
+
+- [ ] `kustomize` binary baked into a versioned, digested custom agent image hosted in Artifactory (`artifactory.cloud.cms.gov`)
+- [ ] Binary version pinned and verified via SHA-256 checksum (even if bundled in image, document version)
+- [ ] No `curl | sh` or dynamic binary download patterns in any Jenkinsfile
+- [ ] Lint check added to CI to reject any `curl.*github` or `wget.*releases` patterns in templates
+
+---
+
+### Story 2.2 — Migrate Secret Provisioner from Static Replication to KSM-Native Fetch
+
+**TRA Rules:** BR-KSM-1, BR-KSM-2, BR-KSM-4, RP-KSM-1, RP-KSM-2  
+**Priority:** High  
+**Effort:** L (1–2 weeks)
+
+**Problem:** `templates/jenkins-secret-provisioner/Jenkinsfile` replicates secrets from Jenkins credentials into static Kubernetes `Secret` objects. This model:
+- Creates a persistent secret copy that may drift from the source of truth
+- Does not leverage CMS KSM (Key and Secret Management) lifecycle controls (rotation, audit, RBAC)
+- Violates BR-KSM-1 (KSM auditing), BR-KSM-2 (KSM RBAC), BR-KSM-4 (credential leak audit)
+
+**Acceptance Criteria:**
+
+- [ ] Secrets fetched at pod startup via KSM integration (e.g., AWS Secrets Manager CSI driver, Vault Agent Injector, or CMS-approved equivalent)
+- [ ] Static `kubectl create secret` calls removed from the Jenkinsfile
+- [ ] All secret access events logged to the CMS security monitoring platform (satisfies BR-KSM-1)
+- [ ] RBAC: service account used by the provisioner has `get`/`list` on secrets only in its own namespace (satisfies BR-KSM-2)
+- [ ] Secret rotation tested: rotating a secret in KSM propagates to pods without a pipeline re-run
+- [ ] A migration runbook created for teams using the old static provisioner
+
+---
+
+### Story 2.3 — Add Policy Gate Before Image Publish (Delivery Pipeline)
+
+**TRA Rules:** BR-OR-1, BR-OR-5, RP-CA-9, RP-CA-10  
+**Priority:** Medium  
+**Effort:** M (4–6 hrs)
+
+**Problem:** The delivery pipeline publishes an image to Artifactory only after Snyk and ClamAV scans, but there is no policy gate that evaluates the combined scan results and blocks publish on any HIGH/CRITICAL finding. The `continue_on_image_scan_failure` bypass (addressed in Story 1.4) is one expression of this gap.
+
+**Acceptance Criteria:**
+
+- [ ] A shared-library `policyGate()` function evaluates:
+  - Snyk container scan: 0 CRITICAL, ≤ threshold HIGH (configurable, default 0)
+  - ClamAV: 0 infections
+  - SBOM generated and attached to build artifact
+- [ ] `policyGate()` called as the final step before `skopeo copy` (publish)
+- [ ] Gate result logged with build URL and image digest to a centralized audit log
+- [ ] Bypass requires a signed exception in the catalog parameter — not a simple boolean
+
+---
+
+### Story 2.4 — Centralize Security Event Logging from All Pipeline Steps
+
+**TRA Rules:** BR-OR-2, BR-OR-3, RP-CA-11  
+**Priority:** Medium  
+**Effort:** L (1–2 weeks)
+
+**Problem:** No Jenkinsfile forwards scan results, policy decisions, or secret-access events to a centralized security monitoring platform. BR-OR-2 requires containers to have security monitoring; BR-OR-3 requires deployment infrastructure to be hardened and monitored.
+
+**Acceptance Criteria:**
+
+- [ ] All security scan results (SonarQube, OWASP DC, Snyk, ClamAV) shipped to the CMS security monitoring platform (SIEM/Splunk/CloudWatch) as structured JSON events
+- [ ] A shared-library `securityEventEmit()` wrapper standardizes the event schema: `{timestamp, pipeline, stage, tool, result, imageDigest, buildUrl}`
+- [ ] Secret provisioner logs every credential access event to the same SIEM
+- [ ] Deployment pipeline logs every `kubectl apply` / `kustomize build` invocation with actor identity
+- [ ] Runbook created for the SOC: "How to query pipeline security events"
+
+---
+
+## Epic 3 — Advanced Maturity (60–90 days)
+
+**Goal:** Achieve artifact signing, provenance attestation, and admission-time enforcement.
+
+---
+
+### Story 3.1 — Sign Published Images and Generate SLSA Provenance Attestations
+
+**TRA Rules:** BR-OR-1, BR-SBI-2, RP-CA-10, RP-CA-11  
+**Priority:** Medium  
+**Effort:** L (1–2 weeks)
+
+**Problem:** Images are published to Artifactory without a cryptographic signature or provenance attestation. A compromised Artifactory account or registry MITM attack can substitute images without detection.
+
+**Acceptance Criteria:**
+
+- [ ] `cosign sign` called after every successful `skopeo copy` using a KSM-managed signing key
+- [ ] SLSA Level 2+ provenance attestation generated via `cosign attest` or `slsa-github-generator` equivalent
+- [ ] Attestation attached to the image manifest in Artifactory
+- [ ] Downstream deployment pipeline verifies signature before `kustomize build` or `kubectl apply`
+- [ ] Signature verification failure blocks deployment (not a warning)
+- [ ] Key rotation process documented and tested
+
+---
+
+### Story 3.2 — Deploy Admission Controller to Enforce Image Policy at Runtime
+
+**TRA Rules:** BR-OR-1, BR-OR-3, RP-CA-1, RP-CA-9  
+**Priority:** Medium  
+**Effort:** XL (3–4 weeks, requires cluster-level access)
+
+**Problem:** Even with pipeline-level controls, nothing prevents a developer with `kubectl` access from deploying an unsigned, unscanned, or `latest`-tagged image directly to the cluster.
+
+**Acceptance Criteria:**
+
+- [ ] Admission webhook (e.g., Kyverno or Gatekeeper) deployed to the CMS cluster
+- [ ] Policy: reject any pod with `imagePullPolicy: Always` + mutable tag (no digest)
+- [ ] Policy: reject any pod whose image lacks a valid cosign signature from the CMS signing key
+- [ ] Policy: enforce pod security context requirements from Story 1.5 at admission time
+- [ ] Policy violation events forwarded to SIEM (Story 2.4)
+- [ ] Dry-run (audit) mode enabled first; enforcement mode gated on 30-day clean audit period
+- [ ] All existing pipeline-deployed workloads validated against policies before enforcement mode
+
+---
+
+### Story 3.3 — Establish Quarterly Pipeline Security Maturity Scorecard
+
+**TRA Rules:** BR-OR-2, BR-OR-3, BR-CCIC-01  
+**Priority:** Low  
+**Effort:** M (ongoing)
+
+**Problem:** There is no mechanism to track regression or improvement in pipeline security posture over time. BR-CCIC-01 requires ATO-level documentation of security controls; the maturity scorecard is the operational artifact that feeds ATO evidence packages.
+
+**Acceptance Criteria:**
+
+- [ ] Scorecard template created in `docs/security/maturity-scorecard.md` covering:
+  - Image hygiene (% pipelines with pinned digests)
+  - Scan gate enforcement (% with non-bypassable gates)
+  - Secret management compliance (% using KSM vs static secrets)
+  - Artifact signing coverage (% images signed)
+  - Pod security context coverage (% pods with required contexts)
+- [ ] Scorecard populated from automated checks (CI job) and reviewed quarterly
+- [ ] Findings fed into the ATO evidence package for the platform
+- [ ] Regression from a previous quarter triggers a P2 remediation ticket within 5 business days
+
+---
+
+## Backlog Summary
+
+| Story | Epic | TRA Rules | Priority | Effort | Target |
+|-------|------|-----------|----------|--------|--------|
+| 1.1 Pin image digests | 1 | BR-OR-1, BR-SBI-2, RP-CA-1 | Critical | S | 0–30 days |
+| 1.2 Remove StrictHostKeyChecking=no | 1 | BR-URL-5, BR-OR-3, RP-CA-6 | Critical | S | 0–30 days |
+| 1.3 Remove credentials from git URL | 1 | BR-URL-5, BR-KSM-4 | Critical | S | 0–30 days |
+| 1.4 Harden scan-bypass parameter | 1 | BR-OR-1, BR-OR-3, RP-CA-9 | High | S | 0–30 days |
+| 1.5 Add pod security contexts | 1 | BR-OR-1, RP-CA-3/4/8 | High | M | 0–30 days |
+| 2.1 Pin kustomize binary in image | 2 | BR-SBI-2, BR-OR-1, RP-SBI-4 | High | M | 30–60 days |
+| 2.2 Migrate to KSM secret fetch | 2 | BR-KSM-1/2/4, RP-KSM-1/2 | High | L | 30–60 days |
+| 2.3 Add publish policy gate | 2 | BR-OR-1, BR-OR-5, RP-CA-9/10 | Medium | M | 30–60 days |
+| 2.4 Centralize security logging | 2 | BR-OR-2, BR-OR-3, RP-CA-11 | Medium | L | 30–60 days |
+| 3.1 Image signing + SLSA provenance | 3 | BR-OR-1, BR-SBI-2, RP-CA-10/11 | Medium | L | 60–90 days |
+| 3.2 Admission controller enforcement | 3 | BR-OR-1, BR-OR-3, RP-CA-1/9 | Medium | XL | 60–90 days |
+| 3.3 Quarterly maturity scorecard | 3 | BR-OR-2, BR-CCIC-01 | Low | M | Ongoing |
+
+---
+
+## References
+
+- [CMS Technical Reference Architecture](https://cms-cloud-service-documentation.atlassian.net/wiki/spaces/CMSTRD/overview)
+- [CMS TRA MCP Server](../cms-tra-mcp-main/)
+- `templates/delivery/Jenkinsfile`
+- `templates/sast/Jenkinsfile`
+- `templates/deployment/Jenkinsfile`
+- `templates/jenkins-secret-provisioner/Jenkinsfile`
+- OWASP Supply Chain Security Top 10
+- SLSA Framework — https://slsa.dev

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -5,13 +5,13 @@ def containerListYaml(snyk_image_tag) {
       imagePullPolicy: Always
       command: ['tail', '-f', '/dev/null']
     - name: sonarqube
-      image: artifactory.cloud.cms.gov/docker/sonarsource/sonar-scanner-cli:5
+      image: artifactory.cloud.cms.gov/docker/sonarsource/sonar-scanner-cli:12.1.0.3225_8.0.1
       imagePullPolicy: Always
       command: ['tail', '-f', '/dev/null']
       resources:
         limits:
-          memory: 3Gi
-          cpu: 1500m""");
+          memory: 4Gi
+          cpu: 2000m""");
 
   if (params.enable_snyk_test) {
     containerListYaml += reindent(10, """
@@ -208,7 +208,7 @@ pipeline {
                       #! /bin/sh -e
                       set +x
                       curl --location '${projectBranchesUrl}' \
-                        --header "Authorization: Basic \$(echo -n \${SONAR_TOKEN}: | base64)" \
+                        --header "Authorization: Bearer \${SONAR_TOKEN}" \\
                         --no-progress-meter -f
                     """,
                     returnStdout: true
@@ -217,7 +217,7 @@ pipeline {
                   def defaultBranch =
                     new groovy.json.JsonSlurper().parseText(projectBranchesJson).branches.find { it.isMain }?.name ?: 'main'
                   def args = [
-                    '-Dsonar.login=$SONAR_TOKEN',
+                    '-Dsonar.token=$SONAR_TOKEN',
                     "-Dsonar.host.url=${params.sonarqube_url}",
                     "-Dsonar.projectKey=${params.sonarqube_project_key}",
                     "-Dsonar.sources=${params.sonarqube_source_path}",

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -160,7 +160,7 @@ pipeline {
     }
     stage("Dependency-Check") {
       when {
-        expression { params.enable_dependency_check }
+        expression { false } // Emergency hard-disable: skip OWASP Dependency-Check entirely
       }
       steps {
         container('dependency-check') {

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -5,7 +5,7 @@ def containerListYaml(snyk_image_tag) {
       imagePullPolicy: Always
       command: ['tail', '-f', '/dev/null']
     - name: dependency-check
-      image: artifactory.cloud.cms.gov/docker/owasp/dependency-check:12.1.0
+      image: artifactory.cloud.cms.gov/docker/owasp/dependency-check-action:latest
       imagePullPolicy: Always
       command: ['tail', '-f', '/dev/null']
     - name: sonarqube
@@ -183,9 +183,24 @@ pipeline {
               def quotedArgs = args.collect { arg ->
                 "'" + arg.toString().replace("'", "'\"'\"'") + "'"
               }.join(' ')
-              sh "dependency-check.sh ${quotedArgs}"
+              sh """#!/bin/sh
+                set -e
+                if command -v dependency-check.sh >/dev/null 2>&1; then
+                  DEPENDENCY_CHECK_BIN=\"\$(command -v dependency-check.sh)\"
+                elif [ -x /usr/share/dependency-check/bin/dependency-check.sh ]; then
+                  DEPENDENCY_CHECK_BIN=/usr/share/dependency-check/bin/dependency-check.sh
+                elif [ -x /usr/share/dependency-check/dependency-check.sh ]; then
+                  DEPENDENCY_CHECK_BIN=/usr/share/dependency-check/dependency-check.sh
+                else
+                  echo 'Unable to locate dependency-check.sh in the dependency-check container.' >&2
+                  echo 'Checked PATH, /usr/share/dependency-check/bin/dependency-check.sh, and /usr/share/dependency-check/dependency-check.sh.' >&2
+                  exit 127
+                fi
+
+                \"\$DEPENDENCY_CHECK_BIN\" ${quotedArgs}
+              """
             } finally {
-              archiveArtifacts artifacts: 'dependency-check-report.json,dependency-check-report.html', allowEmptyArchive: true
+              archiveArtifacts artifacts: 'dependency-check-report.*', allowEmptyArchive: true
             }
           }
         }

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -59,6 +59,7 @@ pipeline {
     string(name: 'copy_artifacts_filter', defaultValue: '', description: 'Optional, a comma separated list of filemasks to identify build artifacts to copy.')
     string(name: 'sonar_scanner_java_opts', defaultValue: "${default_sonar_scanner_java_opts}", description: 'Java options for the SonarQube scanner.')
     booleanParam(name: 'enable_dependency_check', defaultValue: "${default_enable_dependency_check ?: true}", description: 'Run OWASP Dependency-Check before SonarQube so Sonar can ingest the generated report.')
+    booleanParam(name: 'dependency_check_continue_on_error', defaultValue: "${default_dependency_check_continue_on_error ?: true}", description: 'If true, Dependency-Check failures (such as NVD API rate limiting) will mark the build UNSTABLE and continue. If false, the pipeline fails on Dependency-Check errors.')
     string(name: 'dependency_check_source_path', defaultValue: "${default_dependency_check_source_path ?: '.'}", description: 'The relative path of the source code to scan with OWASP Dependency-Check.')
     string(name: 'dependency_check_additional_arguments', defaultValue: "${default_dependency_check_additional_arguments ?: '[]'}", description: 'A JSON serialized array of additional arguments to pass to OWASP Dependency-Check.')
   
@@ -200,6 +201,22 @@ pipeline {
 
                 \"\$DEPENDENCY_CHECK_BIN\" ${quotedArgs}
               """
+            } catch (err) {
+              def errorMessage = err?.toString() ?: 'Unknown Dependency-Check error'
+              def looksLikeNvdRateLimit = (
+                errorMessage ==~ /(?s).*(nvd|NVD).*(429|rate\s*limit|too\s*many\s*requests).*/ ||
+                errorMessage ==~ /(?s).*(429|rate\s*limit|too\s*many\s*requests).*(nvd|NVD).*/
+              )
+
+              if (params.dependency_check_continue_on_error) {
+                if (looksLikeNvdRateLimit) {
+                  unstable('Dependency-Check hit NVD rate limiting (HTTP 429). Continuing pipeline with UNSTABLE status.')
+                } else {
+                  unstable("Dependency-Check failed but is configured to continue on error. Reason: ${errorMessage}")
+                }
+              } else {
+                error "Dependency-Check failed and dependency_check_continue_on_error=false. Reason: ${errorMessage}"
+              }
             } finally {
               archiveArtifacts artifacts: 'dependency-check-report.*', allowEmptyArchive: true
             }

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
     string(name: 'git_change_id', defaultValue: "", description: '(Optional) A unique identifier for a pull request (used by SonarQube to track issues detected in new code).')
     string(name: 'sonarqube_url', defaultValue: "${default_sonarqube_url ?: ''}", description: 'The URL of the SonarQube server.')
     string(name: 'sonarqube_project_key', defaultValue: "${default_sonarqube_project_key ?: ''}", description: 'The SonarQube project key to use when reporting issues.')
+    string(name: 'sonarqube_project_version', defaultValue: "${default_sonarqube_project_version ?: ''}", description: 'The version of the project to report to SonarQube (e.g. 1.0.0, a git tag, or a build number). Shown in the SonarQube dashboard per-analysis.')
     string(name: 'sonarqube_additional_arguments', defaultValue: "${default_sonarqube_additional_arguments ?: ''}", description: 'A JSON serialized array of additional arguments to pass to the SonarQube scanner.')
     string(name: 'sonarqube_source_path', defaultValue: "${default_sonarqube_source_path ?: '.'}", description: 'The relative path of the source code to scan for SonarQube.')
     string(name: 'copy_artifacts_job_name', defaultValue: '', description: 'Optional, name of the Jenkins job from which to copy build artifacts that may be required by the Dockerfile.')
@@ -319,6 +320,9 @@ pipeline {
                     args.add("-Dsonar.branch.name=${branchName}")
                   }
 
+                  if (params.sonarqube_project_version) {
+                    args.add("-Dsonar.projectVersion=${params.sonarqube_project_version}")
+                  }
                   if (params.sonarqube_additional_arguments) {
                     def argArray = new groovy.json.JsonSlurper().parseText(params.sonarqube_additional_arguments)
                     // Add all the items in argArray to the args list

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -108,6 +108,9 @@ pipeline {
                 apk add --no-cache git
               fi
 
+              # Allow git to operate on the workspace regardless of UID differences between containers.
+              git config --global --add safe.directory "${WORKSPACE}"
+
               # Ensure SCM metadata is complete for SonarQube blame/auto-assignment features.
               if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
                 echo "Repository is shallow. Fetching full history..."

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -266,7 +266,10 @@ pipeline {
 
                 // No matter what, make sure the artifacts are archived
                 } finally {
-                  archiveArtifacts artifacts: "${params.snyk_source_path}/snyk-test-vulnerabilities.json", allowEmptyArchive: true
+                  def snykReportArtifactPath = params.snyk_source_path in ['.', './']
+                    ? 'snyk-test-vulnerabilities.json'
+                    : "${params.snyk_source_path}/snyk-test-vulnerabilities.json"
+                  archiveArtifacts artifacts: snykReportArtifactPath, allowEmptyArchive: true
                 }
               } // end script block
             } // end  container snyk

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -93,13 +93,25 @@ pipeline {
               userRemoteConfigs: [[
                 url: "${params.git_repository}",
                 credentialsId: "${params.git_credentials}",
-                refspec: "+${params.git_commit}:refs/remotes/origin/HEAD"
+                refspec: "+refs/heads/*:refs/remotes/origin/* +${params.git_commit}:refs/remotes/origin/HEAD"
               ]],
               extensions: [
-                cloneOption(shallow: true, honorRefspec: true, noTags: true),
-                submodule(recursiveSubmodules: true, shallow: true)
+                cloneOption(shallow: false, honorRefspec: true, noTags: true),
+                submodule(recursiveSubmodules: true, shallow: false)
               ]
             )
+
+            sh '''#!/bin/sh
+              set -e
+              # Ensure SCM metadata is complete for SonarQube blame/auto-assignment features.
+              if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                echo "Repository is shallow. Fetching full history..."
+                git fetch --unshallow origin || git fetch --depth=2147483647 origin
+              fi
+
+              # Ensure all branch refs are available locally for PR and blame analysis.
+              git fetch --tags origin +refs/heads/*:refs/remotes/origin/*
+            '''
 
             if (params.copy_artifacts_job_name && params.copy_artifacts_build_number && params.copy_artifacts_filter) {
               def filters = []

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -180,7 +180,10 @@ pipeline {
             }
 
             try {
-              sh "dependency-check.sh ${args.collect { \"'${it.toString().replace("'", "'\\''")}\" }.join(' ')}"
+              def quotedArgs = args.collect { arg ->
+                "'" + arg.toString().replace("'", "'\"'\"'") + "'"
+              }.join(' ')
+              sh "dependency-check.sh ${quotedArgs}"
             } finally {
               archiveArtifacts artifacts: 'dependency-check-report.json,dependency-check-report.html', allowEmptyArchive: true
             }

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -302,13 +302,18 @@ pipeline {
                     "-Dsonar.dependencyCheck.jsonReportPath=${env.WORKSPACE}/dependency-check-report.json",
                     "-Dsonar.dependencyCheck.htmlReportPath=${env.WORKSPACE}/dependency-check-report.html"
                   ]
-                  if (params.git_branch == defaultBranch) {
-                    echo "Performing analysis for the default branch: ${defaultBranch}"
-                    args.add("-Dsonar.branch.name=${params.git_branch}")
-                  } else {
-                    echo "Performing analysis for a feature branch: ${params.git_branch} (does not match default branch ${defaultBranch})"
+                  if (params.git_change_id) {
+                    echo "Performing pull request analysis for change ${params.git_change_id} on branch ${params.git_branch ?: params.git_commit}"
                     args.add("-Dsonar.pullrequest.branch=${params.git_branch ?: params.git_commit}")
-                    args.add("-Dsonar.pullrequest.key=${params.git_change_id ?: (params.git_branch ?: params.git_commit)}")
+                    args.add("-Dsonar.pullrequest.key=${params.git_change_id}")
+                  } else {
+                    def branchName = params.git_branch ?: defaultBranch
+                    if (branchName == defaultBranch) {
+                      echo "Performing analysis for the default branch: ${defaultBranch}"
+                    } else {
+                      echo "Performing branch analysis for ${branchName} (default branch is ${defaultBranch})"
+                    }
+                    args.add("-Dsonar.branch.name=${branchName}")
                   }
 
                   if (params.sonarqube_additional_arguments) {

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -117,8 +117,6 @@ pipeline {
                 git fetch --unshallow origin || git fetch --depth=2147483647 origin
               fi
 
-              # Ensure all branch refs are available locally for PR and blame analysis.
-              git fetch --tags origin +refs/heads/*:refs/remotes/origin/*
             '''
 
             if (params.copy_artifacts_job_name && params.copy_artifacts_build_number && params.copy_artifacts_filter) {

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -103,6 +103,11 @@ pipeline {
 
             sh '''#!/bin/sh
               set -e
+              if ! command -v git >/dev/null 2>&1; then
+                echo "Git not found in fetch container. Installing git..."
+                apk add --no-cache git
+              fi
+
               # Ensure SCM metadata is complete for SonarQube blame/auto-assignment features.
               if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
                 echo "Repository is shallow. Fetching full history..."

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -58,8 +58,8 @@ pipeline {
     string(name: 'copy_artifacts_build_number', defaultValue: '', description: 'Optional, specific build number of artifacts to copy.')
     string(name: 'copy_artifacts_filter', defaultValue: '', description: 'Optional, a comma separated list of filemasks to identify build artifacts to copy.')
     string(name: 'sonar_scanner_java_opts', defaultValue: "${default_sonar_scanner_java_opts}", description: 'Java options for the SonarQube scanner.')
-    booleanParam(name: 'enable_dependency_check', defaultValue: "${default_enable_dependency_check ?: true}", description: 'Run OWASP Dependency-Check before SonarQube so Sonar can ingest the generated report.')
-    booleanParam(name: 'dependency_check_continue_on_error', defaultValue: "${default_dependency_check_continue_on_error ?: true}", description: 'If true, Dependency-Check failures (such as NVD API rate limiting) will mark the build UNSTABLE and continue. If false, the pipeline fails on Dependency-Check errors.')
+    booleanParam(name: 'enable_dependency_check', defaultValue: "${default_enable_dependency_check == null ? true : default_enable_dependency_check}", description: 'Run OWASP Dependency-Check before SonarQube so Sonar can ingest the generated report.')
+    booleanParam(name: 'dependency_check_continue_on_error', defaultValue: "${default_dependency_check_continue_on_error == null ? true : default_dependency_check_continue_on_error}", description: 'If true, Dependency-Check failures (such as NVD API rate limiting) will mark the build UNSTABLE and continue. If false, the pipeline fails on Dependency-Check errors.')
     string(name: 'dependency_check_source_path', defaultValue: "${default_dependency_check_source_path ?: '.'}", description: 'The relative path of the source code to scan with OWASP Dependency-Check.')
     string(name: 'dependency_check_additional_arguments', defaultValue: "${default_dependency_check_additional_arguments ?: '[]'}", description: 'A JSON serialized array of additional arguments to pass to OWASP Dependency-Check.')
   

--- a/templates/sast/Jenkinsfile
+++ b/templates/sast/Jenkinsfile
@@ -4,6 +4,10 @@ def containerListYaml(snyk_image_tag) {
       image: artifactory.cloud.cms.gov/docker/alpine:3
       imagePullPolicy: Always
       command: ['tail', '-f', '/dev/null']
+    - name: dependency-check
+      image: artifactory.cloud.cms.gov/docker/owasp/dependency-check:12.1.0
+      imagePullPolicy: Always
+      command: ['tail', '-f', '/dev/null']
     - name: sonarqube
       image: artifactory.cloud.cms.gov/docker/sonarsource/sonar-scanner-cli:12.1.0.3225_8.0.1
       imagePullPolicy: Always
@@ -53,6 +57,9 @@ pipeline {
     string(name: 'copy_artifacts_build_number', defaultValue: '', description: 'Optional, specific build number of artifacts to copy.')
     string(name: 'copy_artifacts_filter', defaultValue: '', description: 'Optional, a comma separated list of filemasks to identify build artifacts to copy.')
     string(name: 'sonar_scanner_java_opts', defaultValue: "${default_sonar_scanner_java_opts}", description: 'Java options for the SonarQube scanner.')
+    booleanParam(name: 'enable_dependency_check', defaultValue: "${default_enable_dependency_check ?: true}", description: 'Run OWASP Dependency-Check before SonarQube so Sonar can ingest the generated report.')
+    string(name: 'dependency_check_source_path', defaultValue: "${default_dependency_check_source_path ?: '.'}", description: 'The relative path of the source code to scan with OWASP Dependency-Check.')
+    string(name: 'dependency_check_additional_arguments', defaultValue: "${default_dependency_check_additional_arguments ?: '[]'}", description: 'A JSON serialized array of additional arguments to pass to OWASP Dependency-Check.')
   
     booleanParam(name: 'enable_snyk_test', defaultValue: "${default_enable_snyk_test ?: false}", description: 'Enable Snyk to test code statically.')
     string(name: 'snyk_image_tag', defaultValue: "${default_snyk_image_tag ?: 'alpine'}", description: 'Edit the Snyk Image Tag to reflect the project language.')
@@ -149,6 +156,38 @@ pipeline {
         }
       }
     }
+    stage("Dependency-Check") {
+      when {
+        expression { params.enable_dependency_check }
+      }
+      steps {
+        container('dependency-check') {
+          script {
+            def args = [
+              '--scan', params.dependency_check_source_path,
+              '--project', params.sonarqube_project_key ?: 'dependency-check',
+              '--format', 'JSON',
+              '--format', 'HTML',
+              '--out', env.WORKSPACE,
+              '--prettyPrint'
+            ]
+
+            if (params.dependency_check_additional_arguments) {
+              def argArray = new groovy.json.JsonSlurper().parseText(params.dependency_check_additional_arguments)
+              if (argArray.size() > 0) {
+                args.addAll(argArray)
+              }
+            }
+
+            try {
+              sh "dependency-check.sh ${args.collect { \"'${it.toString().replace("'", "'\\''")}\" }.join(' ')}"
+            } finally {
+              archiveArtifacts artifacts: 'dependency-check-report.json,dependency-check-report.html', allowEmptyArchive: true
+            }
+          }
+        }
+      }
+    }
     stage("Scan Source") {
       parallel {
         stage("Snyk: Test") {
@@ -239,7 +278,11 @@ pipeline {
                     "-Dsonar.host.url=${params.sonarqube_url}",
                     "-Dsonar.projectKey=${params.sonarqube_project_key}",
                     "-Dsonar.sources=${params.sonarqube_source_path}",
-                    "-Dsonar.qualitygate.wait=true"
+                    "-Dsonar.qualitygate.wait=true",
+                    // Override the Dependency-Check plugin default (${WORKSPACE}/dependency-check-report.json)
+                    // which SonarQube treats as a relative path, producing a garbled absolute path.
+                    "-Dsonar.dependencyCheck.jsonReportPath=${env.WORKSPACE}/dependency-check-report.json",
+                    "-Dsonar.dependencyCheck.htmlReportPath=${env.WORKSPACE}/dependency-check-report.html"
                   ]
                   if (params.git_branch == defaultBranch) {
                     echo "Performing analysis for the default branch: ${defaultBranch}"

--- a/templates/sast/README.md
+++ b/templates/sast/README.md
@@ -28,7 +28,7 @@ Additional parameter: `git_change_author` (Pipeline + Template, optional) — So
 
 | Parameter Name | Pipeline | Template | Description | Default Value |
 | --- | --- | --- | --- | --- |
-| enable_dependency_check | X | X | Toggle this to run OWASP Dependency-Check before SonarQube so Sonar can ingest dependency findings. | True |
+| enable_dependency_check | X | X | Toggle this to run OWASP Dependency-Check before SonarQube so Sonar can ingest dependency findings. Disabled by default to avoid long NVD update runtimes unless explicitly needed. | False |
 | dependency_check_continue_on_error | X | X | When true, Dependency-Check failures (such as NVD API rate limiting/HTTP 429) mark the build UNSTABLE and let the rest of the pipeline continue. | True |
 | dependency_check_source_path | X | X | The relative path of the source code to scan with OWASP Dependency-Check. | . |
 | dependency_check_additional_arguments | X | X | A JSON serialized array of additional arguments to pass to OWASP Dependency-Check. | [] |

--- a/templates/sast/README.md
+++ b/templates/sast/README.md
@@ -22,6 +22,16 @@ The SAST Pipeline is a [parameterized pipeline](https://www.jenkins.io/doc/book/
 | build_retention_days           | X        | X        | The number of days to retain build logs and artifacts.                                                                                                   | 90                                        |
 | build_retention_count          | X        | X        | The number of builds to retain.                                                                                                                          | 1000                                      |
 
+Additional parameter: `git_change_author` (Pipeline + Template, optional) — SonarQube username/login of the pull request author, used to auto-assign issues detected in new code during pull request analysis.
+
+## Optional Feature: OWASP Dependency-Check
+
+| Parameter Name | Pipeline | Template | Description | Default Value |
+| --- | --- | --- | --- | --- |
+| enable_dependency_check | X | X | Toggle this to run OWASP Dependency-Check before SonarQube so Sonar can ingest dependency findings. | True |
+| dependency_check_continue_on_error | X | X | When true, Dependency-Check failures (such as NVD API rate limiting/HTTP 429) mark the build UNSTABLE and let the rest of the pipeline continue. | True |
+| dependency_check_source_path | X | X | The relative path of the source code to scan with OWASP Dependency-Check. | . |
+| dependency_check_additional_arguments | X | X | A JSON serialized array of additional arguments to pass to OWASP Dependency-Check. | [] |
 
 ### Optional Feature: Snyk Test
 | Parameter Name                   | Pipeline | Template | Description                                                                                                                          | Default Value |

--- a/templates/sast/template.yaml
+++ b/templates/sast/template.yaml
@@ -38,6 +38,11 @@ parameters:
     description: "When enabled, the pipeline will run OWASP Dependency-Check before SonarQube and publish its report for Sonar ingestion."
     type: boolean
     defaultValue: true
+  - name: default_dependency_check_continue_on_error
+    displayName: Continue on Dependency-Check Error
+    description: "When true, Dependency-Check failures (for example NVD API rate limiting) mark the build UNSTABLE and allow the pipeline to continue."
+    type: boolean
+    defaultValue: true
   - name: default_dependency_check_source_path
     displayName: Dependency-Check Source Path
     description: "The relative path of the source code to scan with OWASP Dependency-Check."

--- a/templates/sast/template.yaml
+++ b/templates/sast/template.yaml
@@ -29,6 +29,21 @@ parameters:
     description: "Java options for the SonarQube scanner."
     type: string
     defaultValue: "-Xmx1g"
+  - name: default_enable_dependency_check
+    displayName: Enable OWASP Dependency-Check
+    description: "When enabled, the pipeline will run OWASP Dependency-Check before SonarQube and publish its report for Sonar ingestion."
+    type: boolean
+    defaultValue: true
+  - name: default_dependency_check_source_path
+    displayName: Dependency-Check Source Path
+    description: "The relative path of the source code to scan with OWASP Dependency-Check."
+    type: string
+    defaultValue: "."
+  - name: default_dependency_check_additional_arguments
+    displayName: Dependency-Check Additional Arguments
+    description: "A JSON serialized array of additional arguments to pass to OWASP Dependency-Check."
+    type: string
+    defaultValue: "[]"
   - name: default_enable_snyk_test
     displayName: Enable Snyk Test
     description: "When enabled, the pipeline will run Sonarqube and Snyk Test in parallel."

--- a/templates/sast/template.yaml
+++ b/templates/sast/template.yaml
@@ -28,7 +28,7 @@ parameters:
     displayName: Sonar Scanner Java Opts
     description: "Java options for the SonarQube scanner."
     type: string
-    defaultValue: "-Xmx512m"
+    defaultValue: "-Xmx1g"
   - name: default_enable_snyk_test
     displayName: Enable Snyk Test
     description: "When enabled, the pipeline will run Sonarqube and Snyk Test in parallel."

--- a/templates/sast/template.yaml
+++ b/templates/sast/template.yaml
@@ -37,7 +37,7 @@ parameters:
     displayName: Enable OWASP Dependency-Check
     description: "When enabled, the pipeline will run OWASP Dependency-Check before SonarQube and publish its report for Sonar ingestion."
     type: boolean
-    defaultValue: true
+    defaultValue: false
   - name: default_dependency_check_continue_on_error
     displayName: Continue on Dependency-Check Error
     description: "When true, Dependency-Check failures (for example NVD API rate limiting) mark the build UNSTABLE and allow the pipeline to continue."

--- a/templates/sast/template.yaml
+++ b/templates/sast/template.yaml
@@ -19,6 +19,10 @@ parameters:
   - name: default_sonarqube_project_key
     displayName: SonarQube Project Key
     type: string
+  - name: default_sonarqube_project_version
+    displayName: SonarQube Project Version
+    description: "The version of the project to report to SonarQube (e.g. 1.0.0, a git tag, or a build number). Shown in the SonarQube dashboard per-analysis."
+    type: string
   - name: default_sonarqube_additional_arguments
     displayName: SonarQube Additional Arguments
     description: "A JSON serialized array of additional arguments to pass to the SonarQube scanner."


### PR DESCRIPTION
Bump SonarQube scanner image to a newer tag and increase container resources (memory 3Gi->4Gi, cpu 1500m->2000m). Change Sonar auth flow to use a Bearer header for SONAR_TOKEN and update the scanner property from -Dsonar.login to -Dsonar.token. Also increase default Java heap for the scanner from -Xmx512m to -Xmx1g. Changes applied in templates/sast/Jenkinsfile and templates/sast/template.yaml.